### PR TITLE
set up dev and prod env

### DIFF
--- a/.htaccess.dist
+++ b/.htaccess.dist
@@ -26,12 +26,10 @@
   RewriteCond %{REQUEST_URI} (.*)/$
   RewriteRule ^(.+)/$ $1 [R,L]
 
-
-  SetEnv DATABASE_USERNAME username_example
-  SetEnv DATABASE_PASSWORD password_example
-
 </IfModule>
 
 <IfModule mod_env.c>
+    SetEnv DATABASE_USERNAME username_example
+    SetEnv DATABASE_PASSWORD password_example
     SetEnv CI_ENV production
 </IfModule>

--- a/.htaccess.dist
+++ b/.htaccess.dist
@@ -31,3 +31,7 @@
   SetEnv DATABASE_PASSWORD password_example
 
 </IfModule>
+
+<IfModule mod_env.c>
+    SetEnv CI_ENV production
+</IfModule>

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -223,7 +223,7 @@ $config['allow_get_array'] = TRUE;
 | your log files will fill up very fast.
 |
 */
-$config['log_threshold'] = 0;
+$config['log_threshold'] = 1;
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
I set up in htaccess the SetEnv CI_ENV variable (development or production). If it is production, then a PHP error return a HTTP 500 error, and no longer the detail of the PHP error. Errors are then registered into the `application\logs` folder. 

Would it be possible/useful to have a custom error page in production, like we already have a custom 404 error page? 