### PR TITLE
Fix/many from log 20210303

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -131,4 +131,4 @@ $route['translate_uri_dashes'] = FALSE;
 // HOMEPAGE
 $route['default_controller'] = 'home/index';
 // 404 PAGE
-$route['404_override'] = 'my404/index';
+$route['404_override'] = 'errormanager/error404';

--- a/application/controllers/Deputes.php
+++ b/application/controllers/Deputes.php
@@ -526,11 +526,13 @@
         }
       }
       // Check the logos
-      foreach ($data["fields_voted"] as $key => $value) {
-        if ($this->functions_datan->get_http_response_code(base_url().'/assets/imgs/fields/'.$value["slug"].'.svg') != "200"){
-          $data['fields_voted'][$key]["logo"] = FALSE;
-        } else {
-          $data['fields_voted'][$key]["logo"] = TRUE;
+      if ($data["fields_voted"]){
+        foreach ($data["fields_voted"] as $key => $value) {
+          if ($this->functions_datan->get_http_response_code(base_url().'/assets/imgs/fields/'.$value["slug"].'.svg') != "200"){
+            $data['fields_voted'][$key]["logo"] = FALSE;
+          } else {
+            $data['fields_voted'][$key]["logo"] = TRUE;
+          }
         }
       }
       $data['by_field'] = $x;

--- a/application/controllers/Errormanager.php
+++ b/application/controllers/Errormanager.php
@@ -1,0 +1,8 @@
+<?php
+class Errormanager extends CI_Controller
+{
+    public function error404()
+    {
+        show_404();
+    }
+}

--- a/application/controllers/Groupes.php
+++ b/application/controllers/Groupes.php
@@ -403,12 +403,14 @@
         }
       }
       // Check the logos
-      foreach ($data["fields_voted"] as $key => $value) {
-        if ($this->functions_datan->get_http_response_code(base_url().'/assets/imgs/fields/'.$value["slug"].'.svg') != "200"){
-          $data['fields_voted'][$key]["logo"] = FALSE;
-        } else {
-          $data['fields_voted'][$key]["logo"] = TRUE;
-        }
+      if ($data["fields_voted"]){
+        foreach ($data["fields_voted"] as $key => $value) {
+          if ($this->functions_datan->get_http_response_code(base_url().'/assets/imgs/fields/'.$value["slug"].'.svg') != "200"){
+            $data['fields_voted'][$key]["logo"] = FALSE;
+          } else {
+            $data['fields_voted'][$key]["logo"] = TRUE;
+          }
+        }  
       }
       $data['by_field'] = $x;
 

--- a/application/views/deputes/votes_datan.php
+++ b/application/views/deputes/votes_datan.php
@@ -91,14 +91,17 @@
         </div>
         <div class="row mt-4">
           <div class="col-12 badges-categories">
-            <?php foreach ($fields_voted as $field): ?>
+            <?php if($fields_voted):
+              foreach ($fields_voted as $field): ?>
               <a class="badge badge-primary no-decoration" href="#<?= $field['slug'] ?>">
                 <?= $field['name'] ?>
               </a>
-            <?php endforeach; ?>
+            <?php endforeach;
+            endif ?>
           </div>
         </div>
-        <?php foreach ($fields_voted as $field): ?>
+        <?php if($fields_voted):
+          foreach ($fields_voted as $field): ?>
           <div class="row mt-5">
             <div class="col-2 col-md-1 d-flex align-items-end justify-content-center p-0">
               <?php if ($field["logo"] == TRUE): ?>
@@ -157,7 +160,8 @@
               </div>
             </div>
           </div>
-        <?php endforeach; ?>
+        <?php endforeach;
+        endif ?>
       </div>
     </div>
   </div> <!-- END CONTAINER -->

--- a/application/views/groupes/votes_datan.php
+++ b/application/views/groupes/votes_datan.php
@@ -93,14 +93,17 @@
         </div>
         <div class="row mt-4">
           <div class="col-12 badges-categories">
-            <?php foreach ($fields_voted as $field): ?>
+            <?php if($fields_voted) :
+            foreach ($fields_voted as $field): ?>
               <a class="badge badge-primary no-decoration" href="#<?= $field['slug'] ?>">
                 <?= $field['name'] ?>
               </a>
-            <?php endforeach; ?>
+            <?php endforeach; 
+            endif ?>
           </div>
         </div>
-        <?php foreach ($fields_voted as $field): ?>
+        <?php if($fields_voted):
+          foreach ($fields_voted as $field): ?>
           <div class="row mt-5">
             <div class="col-2 col-md-1 d-flex align-items-end justify-content-center p-0">
               <?php if ($field["logo"] == TRUE): ?>
@@ -159,7 +162,8 @@
               </div>
             </div>
           </div>
-        <?php endforeach; ?>
+        <?php endforeach;
+                endif ?>
       </div>
     </div>
   </div> <!-- END CONTAINER -->

--- a/scripts/code_photos.php
+++ b/scripts/code_photos.php
@@ -49,7 +49,7 @@ table, th, td {
 
 			// Start RESMUSH CODE
 			// 1.
-			$file = "C:/wamp64/www/datan/assets/imgs/deputes/depute_".$uid.".png";
+			$file = "../assets/imgs/deputes/depute_".$uid.".png";
 			$mime = mime_content_type($file);
 			$info = pathinfo($file);
 			$name = $info['basename'];
@@ -86,7 +86,7 @@ table, th, td {
 			fclose($fp);
 			*/
 			$url = $arr_result->dest;
-			$img = "C:/wamp64/www/datan/assets/imgs/deputes/".$name;
+			$img = "../assets/imgs/deputes/".$name;
 			file_put_contents($img, file_get_contents($url));
 
 			// END RESMUSH

--- a/scripts/code_photos_wepb.php
+++ b/scripts/code_photos_wepb.php
@@ -24,8 +24,8 @@ table, th, td {
 
 		$i = 1;
 
-		$dir = "C:/wamp64/www/datan/assets/imgs/deputes_original/";
-		$newdir = "C:/wamp64/www/datan/assets/imgs/deputes_webp/";
+		$dir = "../assets/imgs/deputes_original/";
+		$newdir = "../assets/imgs/deputes_webp/";
 		$files = scandir($dir);
 		unset($files[0]);
 		unset($files[1]);


### PR DESCRIPTION
Les erreurs sur la page 404 sur asset_url et base_url sont réglés ! Youhou !
En fait quand l'url est /qqch ça partait par ton controller pages qui renvoyait la 404 du coup pas de soucis. même chose pour un depute qui n'existe pas /depute/casimir.
Par contre si c'était /qqch/qqch là l'erreur 404 était géré différemment sans récupérer la lib de codeIgniter du coup c'est bon maintenant. Notamment les url /Votes/legislature-15 (avec la majuscule qui subsiste, qu'à donner le rapport ?).

Les autres erreurs PHP sont corrigées.

Il y avait des erreurs SQL sur la table "deputes_contacts_cleaned" est-ce que des requêtes sont en cache ? Car cette table est supprimée de partout.
